### PR TITLE
docs: add pre-built Ubuntu/Debian package installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,27 @@ I created a discord channel. If:
 
 Please join us: <https://discord.gg/EJSfqHHmaR>.
 
+## Pre-built Packages (Ubuntu / Debian)
+
+Pre-built packages for this module are freely available from the GetPageSpeed repository:
+
+```bash
+# Install the repository keyring
+sudo install -d -m 0755 /etc/apt/keyrings
+curl -fsSL https://extras.getpagespeed.com/deb-archive-keyring.gpg \
+  | sudo tee /etc/apt/keyrings/getpagespeed.gpg >/dev/null
+
+# Add the repository (Ubuntu example - replace 'ubuntu' and 'jammy' for your distro)
+echo "deb [signed-by=/etc/apt/keyrings/getpagespeed.gpg] https://extras.getpagespeed.com/ubuntu jammy main" \
+  | sudo tee /etc/apt/sources.list.d/getpagespeed-extras.list
+
+# Install nginx and the module
+sudo apt-get update
+sudo apt-get install nginx nginx-module-cgi
+```
+
+The module is automatically enabled after installation. Supported distributions include Debian 12/13 and Ubuntu 20.04/22.04/24.04 (both amd64 and arm64). See [the complete setup instructions](https://apt-nginx-extras.getpagespeed.com/apt-setup/).
+
 ## Quick start (with Debian 12+, Ubuntu 24.04+)
 
 Build and install:
@@ -54,7 +75,7 @@ cd nginx-cgi
 ./build-deb-package.sh
 
 # install built package
-dpkg -i ../libnginx-mod-http-cgi_*_amd64.deb 
+dpkg -i ../libnginx-mod-http-cgi_*_amd64.deb
 ```
 
 Then enable cgi in nginx. If you have a newly installed nginx, you can find a


### PR DESCRIPTION
This PR adds installation instructions for pre-built Ubuntu/Debian packages from the GetPageSpeed repository.

The packages are available for:
- Ubuntu 20.04, 22.04, 24.04 (amd64 and arm64)
- Debian 12, 13 (amd64 and arm64)

This makes it easier for users to install the module without compiling from source.